### PR TITLE
Forbidding variable-length secrets

### DIFF
--- a/draft-ietf-tls-hybrid-design.md
+++ b/draft-ietf-tls-hybrid-design.md
@@ -253,7 +253,7 @@ In addition to the primary cryptographic goal, there may be several additional g
 
 - **Low latency:** Use of hybrid key exchange should not substantially increase the latency experienced to establish a connection.  Factors affecting this may include the following.
     - The computational performance characteristics of the specific algorithms used.  See above.
-    - The size of messages to be transmitted.  Public key and ciphertext sizes for post-quantum algorithms range from hundreds of bytes to over one hundred kilobytes, so this impact can be substantially.  See {{BCNS15}}, {{FRODO}} for preliminary results in a laboratory setting, and {{LANGLEY}} for preliminary results on more realistic networks.
+    - The size of messages to be transmitted.  Public key and ciphertext sizes for post-quantum algorithms range from hundreds of bytes to over one hundred kilobytes, so this impact can be substantial.  See {{BCNS15}}, {{FRODO}} for preliminary results in a laboratory setting, and {{LANGLEY}} for preliminary results on more realistic networks.
     - Additional round trips added to the protocol.  See below.
 
 - **No extra round trips:** Attempting to negotiate hybrid key exchange should not lead to extra round trips in any of the three hybrid-aware/non-hybrid-aware scenarios listed above.  
@@ -433,7 +433,7 @@ Therefore, this specification MUST only be used with algorithms which have fixed
 
 # Acknowledgements
 
-These ideas have grown from discussions with many colleagues, including Christopher Wood, Matt Campagna, Eric Crockett, authors of the various hybrid Internet-Drafts and implementations cited in this document, and members of the TLS working group.  The immediate impetus for this document came from discussions with attendees at the Workshop on Post-Quantum Software in Mountain View, California, in January 2019.  Martin Thomson suggested the [(Comb-KDF-1)](#comb-kdf-1) approach.  Daniel J. Bernstein and Tanja Lange commented on the risks of reuse of ephemeral public keys.  Matt Campagna and the team at Amazon Web Services provided additional suggestions.
+These ideas have grown from discussions with many colleagues, including Christopher Wood, Matt Campagna, Eric Crockett, authors of the various hybrid Internet-Drafts and implementations cited in this document, and members of the TLS working group.  The immediate impetus for this document came from discussions with attendees at the Workshop on Post-Quantum Software in Mountain View, California, in January 2019.  Martin Thomson suggested the [(Comb-KDF-1)](#comb-kdf-1) approach.  Daniel J. Bernstein and Tanja Lange commented on the risks of reuse of ephemeral public keys.  Matt Campagna and the team at Amazon Web Services provided additional suggestions.  Nimrod Aviram proposed restricting to fixed-length secrets.
 
 --- back
 

--- a/draft-ietf-tls-hybrid-design.md
+++ b/draft-ietf-tls-hybrid-design.md
@@ -95,9 +95,9 @@ informative:
     title: "Lucky Thirteen: Breaking the TLS and DTLS record protocols"
     author:
     -
-      ins: NJ Al Fardan
+      ins: N. J. Al Fardan
     -
-      ins: KG Paterson
+      ins: K. G. Paterson
   NIELSEN:
     title: Quantum Computation and Quantum Information
     author:
@@ -143,7 +143,7 @@ informative:
       org: Open Quantum Safe Project
     date: 2018-11
   RACCOON:
-    target: "TBD (waiting for ePrint URL)"
+    target: https://raccoon-attack.com/
     title: "Raccoon Attack: Finding and Exploiting Most-Significant-Bit-Oracles in TLS-DH(E)"
     author:
     -


### PR DESCRIPTION
Following discussion on the mailing list, this PR removes language allowing for potential future use of variable-length secrets.
It also adds a security consideration stating that secrets should be constant length.