### PR TITLE
Change-shared-secret-justification

### DIFF
--- a/draft-ietf-tls-hybrid-design.md
+++ b/draft-ietf-tls-hybrid-design.md
@@ -372,7 +372,7 @@ For the client's share, the `key_exchange` value contains the concatenation of t
 
 ## Shared secret calculation {#construction-shared-secret}
 
-Here we also take a simple "concatenation approach": the two shared secrets are concatenated together and used as the shared secret in the existing TLS 1.3 key schedule.  Again, we do not add any additional structure (length fields) in the concatenation procedure: among all Round 3 finalists and alternate candidates, once the algorithm and variant are specified, the shared secret output length is fixed.
+Here we also take a simple "concatenation approach": the two shared secrets are concatenated together and used as the shared secret in the existing TLS 1.3 key schedule.  Again, we do not add any additional structure (length fields) in the concatenation procedure: for both the traditional groups and Kyber, the shared secret output length is fixed for a specific elliptic curve or parameter set.
 
 In other words, the shared secret is calculated as
 


### PR DESCRIPTION
This changes text to avoid talking about 'round 3' candidates; focusing only on Kyber